### PR TITLE
fix(nav): reduce orange hover flood on nav links

### DIFF
--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -275,7 +275,8 @@ const isActive = (href: string) => (href === "/" ? currentPath === "/" : current
               aria-current={isActive(href) ? "page" : undefined}
               class={cn(
                 buttonVariants({ variant: isActive(href) ? "default" : "ghost" }),
-                isActive(href) ? "font-bold" : ""
+                isActive(href) ? "font-bold" : "",
+      !isActive(href) && "border border-[var(--outline)] text-[var(--accent)] hover:text-[#ffd199] hover:border-[rgba(255,145,0,.65)] hover:bg-[rgba(255,145,0,.08)] transition-all"
               )}
             >
               {label}


### PR DESCRIPTION
The nav link "ghost" variant used a hover background color `--accent` (#ff9100), which caused an overwhelming orange flood when hovering over navigation items like "About". This commit modifies the `class` attribute for nav links in `SiteLayout.astro` to override the ghost variant styles when the link is not active. The new classes:
- add a border (`border border-[var(--outline)]`)
- change text color to accent (`text-[var(--accent)]`)
- lighten the hover background and text (`hover:text-[#ffd199]`, `hover:border-[rgba(255,145,0,.65)]`, `hover:bg-[rgba(255,145,0,.08)]`)
- apply a transition effect (`transition-all`)

This results in a more subtle hover effect that aligns better with the site's design.