### PR TITLE
Refresh nbdevlab branding and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-For my website, yes this repo is a hot mess, I use it to learn.
+# nbdevlab
+
+A personal playground for Nathan Bullock to experiment with Astro, Cloudflare Workers, and a growing collection of homelab notes. The site documents projects, publishes long-form write ups, and tracks the state of the infrastructure that powers nbdevlab.com.
+
+## Highlights
+- **Living lab notebook** – project logs and field notes captured as Markdown content collections.
+- **Status + telemetry** – lightweight dashboards surface uptime snapshots and current areas of focus.
+- **Hand-crafted UI** – Tailwind CSS, shadcn/ui, and custom theming create a cohesive dark interface without starter template clutter.
+
+## Tech Stack
+- [Astro](https://astro.build/) for static-first site generation with islands of interactivity.
+- [Cloudflare Workers](https://workers.cloudflare.com/) + [Wrangler](https://developers.cloudflare.com/workers/wrangler/) for edge deployment.
+- [Tailwind CSS](https://tailwindcss.com/) and [shadcn/ui](https://ui.shadcn.com/) for component styling.
+- [Decap CMS](https://decapcms.org/) for authenticated content editing via GitHub OAuth.
+
+## Local Development
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Start the dev server**
+   ```bash
+   npm run dev
+   ```
+   The site becomes available at the address printed in the terminal.
+3. **Generate content types (optional)**
+   ```bash
+   npm run sync
+   ```
+   Syncs content collections defined in `src/content/config.ts`.
+
+## Deployment
+Deployments target Cloudflare Workers via `wrangler`. Build locally and publish with:
+```bash
+npm run build
+npm run deploy
+```
+
+## License
+This repository represents personal work. Please reach out before reusing significant portions of the design or content.

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,20 +1,15 @@
 import * as React from "react"
 import {
-  IconCamera,
-  IconChartBar,
+  IconBrandGithub,
   IconDashboard,
-  IconDatabase,
-  IconFileAi,
   IconFileDescription,
-  IconFileWord,
   IconFolder,
   IconHelp,
   IconInnerShadowTop,
   IconListDetails,
+  IconMail,
   IconReport,
-  IconSearch,
   IconSettings,
-  IconUsers,
 } from "@tabler/icons-react"
 
 import { NavDocuments } from "@/components/nav-documents"
@@ -33,117 +28,74 @@ import {
 
 const data = {
   user: {
-    name: "shadcn",
-    email: "m@example.com",
-    avatar: "/avatars/shadcn.jpg",
+    name: "Nathan Bullock",
+    email: "hello@nbdevlab.com",
+    avatar: "/favicon.svg",
   },
   navMain: [
     {
-      title: "Dashboard",
-      url: "#",
+      title: "Overview",
+      url: "/",
       icon: IconDashboard,
     },
     {
-      title: "Lifecycle",
-      url: "#",
-      icon: IconListDetails,
-    },
-    {
-      title: "Analytics",
-      url: "#",
-      icon: IconChartBar,
-    },
-    {
       title: "Projects",
-      url: "#",
+      url: "/projects/",
       icon: IconFolder,
     },
     {
-      title: "Team",
-      url: "#",
-      icon: IconUsers,
-    },
-  ],
-  navClouds: [
-    {
-      title: "Capture",
-      icon: IconCamera,
-      isActive: true,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
-    },
-    {
-      title: "Proposal",
+      title: "Writing",
+      url: "/blog/",
       icon: IconFileDescription,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
     },
     {
-      title: "Prompts",
-      icon: IconFileAi,
-      url: "#",
-      items: [
-        {
-          title: "Active Proposals",
-          url: "#",
-        },
-        {
-          title: "Archived",
-          url: "#",
-        },
-      ],
+      title: "Status Board",
+      url: "/status/",
+      icon: IconReport,
+    },
+    {
+      title: "About",
+      url: "/about/",
+      icon: IconListDetails,
     },
   ],
   navSecondary: [
     {
       title: "Settings",
-      url: "#",
+      url: "/admin/",
       icon: IconSettings,
     },
     {
-      title: "Get Help",
-      url: "#",
-      icon: IconHelp,
+      title: "Contact",
+      url: "mailto:hello@nbdevlab.com",
+      icon: IconMail,
     },
     {
-      title: "Search",
-      url: "#",
-      icon: IconSearch,
+      title: "GitHub",
+      url: "https://github.com/0xC0FFEEBEEF/nbdevlab",
+      icon: IconBrandGithub,
+    },
+    {
+      title: "Colophon",
+      url: "/about/#colophon",
+      icon: IconHelp,
     },
   ],
   documents: [
     {
-      name: "Data Library",
-      url: "#",
-      icon: IconDatabase,
+      name: "Project Archive",
+      url: "/projects/",
+      icon: IconFolder,
     },
     {
-      name: "Reports",
-      url: "#",
+      name: "Status Log",
+      url: "/status/",
       icon: IconReport,
     },
     {
-      name: "Word Assistant",
-      url: "#",
-      icon: IconFileWord,
+      name: "Writing Handbook",
+      url: "/about/",
+      icon: IconFileDescription,
     },
   ],
 }
@@ -160,7 +112,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             >
               <a href="#">
                 <IconInnerShadowTop className="!size-5" />
-                <span className="text-base font-semibold">Acme Inc.</span>
+                <span className="text-base font-semibold">nbdevlab</span>
               </a>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/src/components/nav-documents.tsx
+++ b/src/components/nav-documents.tsx
@@ -38,7 +38,7 @@ export function NavDocuments({
 
   return (
     <SidebarGroup className="group-data-[collapsible=icon]:hidden">
-      <SidebarGroupLabel>Documents</SidebarGroupLabel>
+      <SidebarGroupLabel>Resources</SidebarGroupLabel>
       <SidebarMenu>
         {items.map((item) => (
           <SidebarMenuItem key={item.name}>
@@ -80,12 +80,6 @@ export function NavDocuments({
             </DropdownMenu>
           </SidebarMenuItem>
         ))}
-        <SidebarMenuItem>
-          <SidebarMenuButton className="text-sidebar-foreground/70">
-            <IconDots className="text-sidebar-foreground/70" />
-            <span>More</span>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
       </SidebarMenu>
     </SidebarGroup>
   )

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,6 +1,5 @@
-import { IconCirclePlusFilled, IconMail, type Icon } from "@tabler/icons-react"
+import { type Icon } from "@tabler/icons-react"
 
-import { Button } from "@/components/ui/button"
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -20,32 +19,15 @@ export function NavMain({
 }) {
   return (
     <SidebarGroup>
-      <SidebarGroupContent className="flex flex-col gap-2">
-        <SidebarMenu>
-          <SidebarMenuItem className="flex items-center gap-2">
-            <SidebarMenuButton
-              tooltip="Quick Create"
-              className="bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground active:bg-primary/90 active:text-primary-foreground min-w-8 duration-200 ease-linear"
-            >
-              <IconCirclePlusFilled />
-              <span>Quick Create</span>
-            </SidebarMenuButton>
-            <Button
-              size="icon"
-              className="size-8 group-data-[collapsible=icon]:opacity-0"
-              variant="outline"
-            >
-              <IconMail />
-              <span className="sr-only">Inbox</span>
-            </Button>
-          </SidebarMenuItem>
-        </SidebarMenu>
+      <SidebarGroupContent>
         <SidebarMenu>
           {items.map((item) => (
             <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton tooltip={item.title}>
-                {item.icon && <item.icon />}
-                <span>{item.title}</span>
+              <SidebarMenuButton asChild tooltip={item.title}>
+                <a href={item.url}>
+                  {item.icon && <item.icon />}
+                  <span>{item.title}</span>
+                </a>
               </SidebarMenuButton>
             </SidebarMenuItem>
           ))}

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -1,8 +1,8 @@
 import {
-  IconCreditCard,
   IconDotsVertical,
   IconLogout,
   IconNotification,
+  IconSettings,
   IconUserCircle,
 } from "@tabler/icons-react"
 
@@ -37,6 +37,12 @@ export function NavUser({
   }
 }) {
   const { isMobile } = useSidebar()
+  const initials = user.name
+    .split(/\s+/)
+    .map((part) => part[0] ?? "")
+    .join("")
+    .slice(0, 2)
+    .toUpperCase()
 
   return (
     <SidebarMenu>
@@ -49,7 +55,7 @@ export function NavUser({
             >
               <Avatar className="h-8 w-8 rounded-lg grayscale">
                 <AvatarImage src={user.avatar} alt={user.name} />
-                <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                <AvatarFallback className="rounded-lg">{initials}</AvatarFallback>
               </Avatar>
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-medium">{user.name}</span>
@@ -70,7 +76,7 @@ export function NavUser({
               <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                 <Avatar className="h-8 w-8 rounded-lg">
                   <AvatarImage src={user.avatar} alt={user.name} />
-                  <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                  <AvatarFallback className="rounded-lg">{initials}</AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-medium">{user.name}</span>
@@ -87,8 +93,8 @@ export function NavUser({
                 Account
               </DropdownMenuItem>
               <DropdownMenuItem>
-                <IconCreditCard />
-                Billing
+                <IconSettings />
+                Preferences
               </DropdownMenuItem>
               <DropdownMenuItem>
                 <IconNotification />

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -37,12 +37,15 @@ export function NavUser({
   }
 }) {
   const { isMobile } = useSidebar()
-  const initials = user.name
-    .split(/\s+/)
-    .map((part) => part[0] ?? "")
-    .join("")
-    .slice(0, 2)
-    .toUpperCase()
+  const initials =
+    typeof user.name === "string" && user.name.trim().length > 0
+      ? user.name
+          .split(/\s+/)
+          .map((part) => part[0] ?? "")
+          .join("")
+          .slice(0, 2)
+          .toUpperCase()
+      : "NA";
 
   return (
     <SidebarMenu>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -11,16 +11,16 @@ export function SiteHeader() {
           orientation="vertical"
           className="mx-2 data-[orientation=vertical]:h-4"
         />
-        <h1 className="text-base font-medium">Documents</h1>
+        <h1 className="text-base font-medium">nbdevlab</h1>
         <div className="ml-auto flex items-center gap-2">
           <Button variant="ghost" asChild size="sm" className="hidden sm:flex">
             <a
-              href="https://github.com/shadcn-ui/ui/tree/main/apps/v4/app/(examples)/dashboard"
+              href="https://github.com/0xC0FFEEBEEF/nbdevlab"
               rel="noopener noreferrer"
               target="_blank"
               className="dark:text-foreground"
             >
-              GitHub
+              View Source
             </a>
           </Button>
         </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,12 +42,12 @@ import { cn } from "../lib/utils";
       };
       const prompt = () => `<span style=\"color:${palette.user}\">nbullock@homelab</span> <span style=\"color:${palette.path}\">~/lab</span> <span style=\"color:${palette.branch}\">main</span> <span style=\"color:${palette.symbol}\">$\n</span>`;
       const scriptLines = [
-        `${prompt()}npx create-astro@latest`,
-        `› Selecting features: <span style=\"color:${palette.accent}\">tailwind, react, mdx</span>`,
-        `› Installing packages… <span style=\"color:#10b981\">done</span>`,
-        `› Initializing git… <span style=\"color:#10b981\">ok</span>`,
-        `deploy --target=cloudflare` ,
-        `<span style=\"color:#f59e0b\">→</span> shipping artifacts`,
+        `${prompt()}git status`,
+        `<span style=\"color:${palette.accent}\">→</span> workspace clean`,
+        `${prompt()}npm run sync`,
+        `<span style=\"color:${palette.accent}\">→</span> content collections refreshed`,
+        `${prompt()}npm run build`,
+        `<span style=\"color:${palette.accent}\">→</span> wrangler deploy --env production`,
         `<span style=\"color:#ff9100">✓</span> live at https://www.nbdevlab.com`,
       ];
       let lineIndex = 0, charIndex = 0, buffer = '';


### PR DESCRIPTION
## Summary
- rewrite the README with highlights, tech stack, and workflow details specific to nbdevlab
- replace template sidebar data and user menu content with site-branded links and copy
- update the landing page terminal animation and header actions to reflect the actual deployment flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fbf7d414748325aad989589f382f24