### PR TITLE
Update project schema and content processing for build compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "scripts": {
     "astro": "astro",
-    "prebuild": "node scripts/validate-projects.mjs",
+    "prebuild": "node scripts/ensure-astro-slug.mjs && node scripts/validate-projects.mjs",
     "build": "astro build",
     "check": "astro check && tsc --noEmit",
     "dev": "astro dev",

--- a/scripts/ensure-astro-slug.mjs
+++ b/scripts/ensure-astro-slug.mjs
@@ -1,0 +1,27 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const targetPath = join(process.cwd(), "node_modules", "astro", "dist", "content", "utils.js");
+const originalSnippet =
+  "const { slug, ...unvalidatedData } = entry.unvalidatedData;\n    data = unvalidatedData;";
+const patchedSnippet =
+  "const { slug, ...unvalidatedData } = entry.unvalidatedData;\n    data = slug === undefined ? unvalidatedData : { slug, ...unvalidatedData };";
+
+try {
+  const source = await readFile(targetPath, "utf8");
+  if (source.includes(patchedSnippet)) {
+    console.log("Astro slug patch already applied.");
+  } else if (source.includes(originalSnippet)) {
+    const updated = source.replace(originalSnippet, patchedSnippet);
+    await writeFile(targetPath, updated, "utf8");
+    console.log("Applied Astro slug patch to preserve frontmatter slug field.");
+  } else {
+    console.warn("Unable to locate Astro slug patch target. Build may fail if slug is required in schema.");
+  }
+} catch (error) {
+  if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+    console.warn("Astro utils file not found; skipping slug patch.");
+  } else {
+    throw error;
+  }
+}

--- a/scripts/validate-projects.mjs
+++ b/scripts/validate-projects.mjs
@@ -4,24 +4,81 @@ import { join, basename } from "node:path";
 const PROJECT_DIR = join(process.cwd(), "src", "content", "projects");
 const REQUIRED_FIELDS = [
   "title",
+  "slug",
   "date",
   "status",
   "tags",
-  "problem",
   "constraints",
   "stack",
   "lessons",
 ];
 
+const STATUS_VALUES = new Set(["draft", "published"]);
 const SLUG_PATTERN = /^[a-z0-9]+(?:[\-_][a-z0-9]+)*$/;
 
-const sanitizeSlug = (value) =>
+const sanitizeSlug = (value = "") =>
   value
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9\-_]+/g, "-")
     .replace(/-{2,}/g, "-")
     .replace(/^-|-$/g, "");
+
+const parseFrontmatter = (source) => {
+  const match = source.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) {
+    return { data: null, raw: null };
+  }
+
+  const raw = match[1];
+  const data = {};
+  let currentArray = null;
+
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+
+    if (trimmed === "" || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const arrayItemMatch = line.match(/^\s*-\s+(.+)$/);
+    if (arrayItemMatch && currentArray) {
+      const value = arrayItemMatch[1].trim().replace(/^"|"$/g, "");
+      data[currentArray].push(value);
+      continue;
+    }
+
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex === -1) {
+      currentArray = null;
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const rawValue = line.slice(separatorIndex + 1).trim();
+
+    if (rawValue === "") {
+      currentArray = key;
+      data[key] = [];
+      continue;
+    }
+
+    currentArray = null;
+
+    if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
+      const items = rawValue
+        .slice(1, -1)
+        .split(",")
+        .map((item) => item.trim().replace(/^"|"$/g, ""))
+        .filter(Boolean);
+      data[key] = items;
+    } else {
+      data[key] = rawValue.replace(/^"|"$/g, "");
+    }
+  }
+
+  return { data, raw };
+};
 
 const files = await readdir(PROJECT_DIR, { withFileTypes: true });
 const seen = new Map();
@@ -31,32 +88,18 @@ for (const entry of files) {
   if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
   const filePath = join(PROJECT_DIR, entry.name);
   const source = await readFile(filePath, "utf8");
-  const match = source.match(/^---\n([\s\S]*?)\n---/);
+  const { data, raw } = parseFrontmatter(source);
 
-  if (!match) {
+  if (!data) {
     console.warn(`⚠️  ${entry.name}: missing front-matter block.`);
     issues++;
     continue;
   }
 
-  const frontmatter = match[1];
-
-  const readField = (field) => {
-    const regex = new RegExp(`^${field}:\s*(.+)$`, "m");
-    const fieldMatch = frontmatter.match(regex);
-    if (!fieldMatch) return undefined;
-    return fieldMatch[1].trim().replace(/^"|"$/g, "");
-  };
-
-  const hasArrayField = (field) => {
-    const regex = new RegExp(`^${field}:\s*\n(\s*-\s+.+\n?)+`, "m");
-    return regex.test(frontmatter);
-  };
-
-  const slugSource = readField("slug") || basename(entry.name, ".md");
+  const slugSource = data.slug || basename(entry.name, ".md");
   const derivedSlug = sanitizeSlug(slugSource);
 
-  if (!readField("title")) {
+  if (!data.title) {
     console.warn(`⚠️  ${entry.name}: missing required field "title".`);
     issues++;
   }
@@ -67,15 +110,24 @@ for (const entry of files) {
   }
 
   for (const field of REQUIRED_FIELDS) {
+    const value = data[field];
+
     if (["tags", "constraints", "stack", "lessons"].includes(field)) {
-      if (!hasArrayField(field)) {
+      if (!Array.isArray(value) || value.length === 0) {
         console.warn(`⚠️  ${entry.name}: field "${field}" must list at least one item.`);
         issues++;
       }
-    } else if (!readField(field)) {
+    } else if (!value) {
       console.warn(`⚠️  ${entry.name}: missing required field "${field}".`);
       issues++;
     }
+  }
+
+  if (data.status && !STATUS_VALUES.has(data.status)) {
+    console.warn(
+      `⚠️  ${entry.name}: status "${data.status}" must be one of ${Array.from(STATUS_VALUES).join(", ")}.`
+    );
+    issues++;
   }
 
   const key = derivedSlug;

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,32 @@
+import { defineCollection, z } from "astro:content";
+
+const projects = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    slug: z.string(),
+    // Keep 'date' as STRING to match existing content
+    date: z.string(),
+    status: z.enum(["draft", "published"]).default("published"),
+    tags: z.array(z.string()).min(1),
+    constraints: z.array(z.string()).min(1),
+    stack: z.array(z.string()).min(1),
+    lessons: z.array(z.string()).min(1),
+    links: z
+      .object({
+        repo: z.string().url().optional(),
+        demo: z.string().url().optional(),
+      })
+      .optional(), // allow omitting links entirely
+  }),
+});
+
+// Define 'pages' explicitly to avoid auto-generation deprecation
+const pages = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string().optional(),
+  }),
+});
+
+export const collections = { projects, pages };

--- a/src/content/projects/cloudflare-workers-github-cache.md
+++ b/src/content/projects/cloudflare-workers-github-cache.md
@@ -1,8 +1,8 @@
 ---
 title: "Cloudflare Workers GitHub Cache"
-slug: "cloudflare-workers-github-cache"
+slug: cloudflare-workers-github-cache
 date: "2025-09-07"
-status: "building"
+status: "published"
 tags:
   - observability
   - integrations

--- a/src/content/projects/two-node-proxmox-homelab-with-zero-trust-remote-access-power-aware-backups.md
+++ b/src/content/projects/two-node-proxmox-homelab-with-zero-trust-remote-access-power-aware-backups.md
@@ -1,93 +1,60 @@
 ---
-title: Two-Node Proxmox Homelab with Zero-Trust Remote Access & Power-Aware Backups
-slug: proxmox-homelab-byteme2-byteme3
-date: 2025-10-26
-status: building
+title: "Two-Node Proxmox Homelab with Zero-Trust Remote Access & Power-Aware Backups"
+slug: "proxmox-homelab-byteme2-byteme3"
+date: "2025-10-26"
+status: "published"
+
 tags:
   - Proxmox
-  - Homelab
   - Cloudflare Zero Trust
-  - ProLiant
-  - IPMI/iLO
   - Proxmox Backup Server
   - VLAN Segmentation
-  - Energy Efficiency
+  - Observability
+
+constraints:
+  - Sanitize IP/URL details in public docs
+  - Zero Trust only (no public exposure)
+  - Power-aware backups (boot PBS, shutdown after)
+
+stack:
+  - Proxmox VE
+  - PBS
+  - WatchGuard/Firebox
+  - Cloudflare Tunnel
   - Zabbix
   - Grafana
   - Wazuh
-problem: I needed a secure, reliable homelab I could reach from anywhere without
-  exposing services directly to the internet—and I wanted backups without
-  keeping a second server idling 24/7.
-constraints:
-  - "No public exposure of management planes (Zero Trust only)  Private
-    addressing only; sanitized 10.0.x.0/24 ranges segmented by role  Power
-    budget: the backup node should be off except during jobs  Keep costs low;
-    reuse enterprise hardware  Don’t publish detailed IP/URL schemes in public
-    docs"
-stack:
-  - "Compute/Virtualization: Proxmox VE on two nodes  byteme2: HPE ProLiant
-    (primary"
-  - "runs most services + Cloudflare tunnel)  byteme3: Intel S1600JP (PBS +
-    overflow; normally powered off)  Backups: Proxmox Backup Server on
-    byteme3  Power Control: BMC/IPMI/iLO triggered from byteme2  Network &
-    Security: WatchGuard/Firebox (mixed routing)"
-  - VLAN segmentation (Wireless / Management / Servers / Lab in 10.0.x.0/24
-    ranges)
-  - "least-privilege inter-VLAN rules  Remote Access: Cloudflare Zero Trust
-    (Access + cloudflared) fronting RDP and internal web apps  Observability:
-    Zabbix + Grafana; Wazuh for security telemetry  Guests/Services (examples):
-    directory/DNS"
-  - monitoring stack
-  - code hosting
-  - sandboxes (mix of QEMU + LXC/Debian/Ubuntu)
+
 lessons:
-  - "Zero Trust beats port-forwarding; posture + SSO keeps attack surface
-    tiny  Segment first—VLANs limit blast radius far better than later
-    cleanup  Power-aware backups matter: BMC boot → PBS job → graceful shutdown
-    saves watts and noise  Add health-check gates so shutdown only happens after
-    successful jobs  Keep published apps minimal; use catch-all rules for
-    anything unexpected  Document publicly with sanitized ranges/hostnames only"
-links:
-  repo: ""
+  - Zero Trust beats port-forwarding
+  - Segment first; limit east-west
+  - Gate shutdown on successful PBS jobs
+
+# links:                 # leave commented out unless you have real URLs
+#   repo: "https://example.com/repo"
+#   demo: "https://demo.example.com"
 ---
+
 **TL;DR**  
 Two-node Proxmox lab with Zero Trust remote access, segmented networks, and power-aware backups. The primary node stays online; the backup node wakes only for jobs, then shuts down cleanly.
 
-## Goals
-- Secure remote access without public exposure  
-- Reliable, automated backups with minimal idle power draw  
-- Clean network segmentation for safer experimentation
-
 ## Topology
-- **byteme2** — Primary ProLiant compute node (Proxmox). Runs most services, Cloudflare tunnels, and orchestration.  
-- **byteme3** — Secondary Intel server (Proxmox/PBS). Normally off; used for backups and overflow compute.
+- **byteme2** — Primary compute node (Proxmox). Runs most services and the Cloudflare tunnel.
+- **byteme3** — Secondary server (Proxmox/PBS). Normally off; used for backups/overflow.
 
 ## Network (Sanitized)
-- Private **10.0.x.0/24** address spaces with VLANs for **Wireless**, **Management**, **Servers**, and **Lab**.  
-- Mixed-routing firewall enforces least-privilege east-west access.  
-- Management surfaces restricted to the management segment + Zero Trust.
+Private **10.0.x.0/24** ranges segmented by role (Wireless / Management / Servers / Lab). Inter-VLAN routing on the firewall with least-privilege rules.
 
 ## Remote Access & Security
-- **Cloudflare Zero Trust/Access** fronts RDP and internal web UIs behind SSO and device posture checks.  
-- Tunnels originate from byteme2; only the required apps/routes are published.  
-- Catch-all rules handle unexpected requests.
+Cloudflare Zero Trust/Access fronts RDP and internal web UIs behind SSO and device posture checks. Catch-all rules handle unexpected requests.
 
 ## Backups & Power Orchestration
-1. byteme2 sends a **BMC/IPMI power-on** to byteme3 before the backup window.  
-2. **Proxmox Backup Server** jobs run to PBS storage on byteme3.  
-3. On success, byteme2 issues a **graceful shutdown** to byteme3.  
-_Result:_ dependable restore points without 24/7 idle power on the backup node.
+1) byteme2 sends a **BMC/IPMI power-on** to byteme3 before the backup window.  
+2) PBS jobs run to storage on byteme3.  
+3) On success, byteme2 issues a **graceful shutdown** to byteme3.
 
 ## Observability
-- Zabbix + Grafana dashboards for host/vm metrics and capacity trends.  
-- Wazuh for security telemetry and alerting.
+Zabbix + Grafana for metrics; Wazuh for security telemetry and alerting.
 
 ## Results
-- Strong remote posture with **no direct exposure**.  
-- Lower power usage and noise by powering the backup node only when needed.  
-- Safer tinkering thanks to VLAN segmentation and scoped policies.
-
-## What’s Next
-- Gate shutdown on explicit PBS job success + storage health checks.  
-- IaC/runbooks for Cloudflare Access app inventory and firewall policies.  
-- Expand per-VLAN traffic and PBS capacity visualizations in Grafana.
+Strong remote posture with no direct exposure, lower power usage by powering the backup node only when needed, and safer tinkering via VLAN segmentation.

--- a/src/content/projects/wazuh-bruteforce-runbook.md
+++ b/src/content/projects/wazuh-bruteforce-runbook.md
@@ -2,7 +2,7 @@
 title: "Wazuh Bruteforce Runbook"
 slug: "wazuh-bruteforce-runbook"
 date: "2025-05-18"
-status: "shipped"
+status: "published"
 tags:
   - security
   - automation

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -9,12 +9,14 @@ const [projects, posts] = await Promise.all([
   getCollection("blog"),
 ]);
 
+const toDate = (value: unknown) => (value instanceof Date ? value : new Date(String(value)));
+
 const recentProjects = projects
   .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
   .slice(0, 3);
 
 const recentPosts = posts
-  .sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime())
+  .sort((a, b) => toDate(b.data.pubDate).getTime() - toDate(a.data.pubDate).getTime())
   .slice(0, 3);
 ---
 
@@ -46,7 +48,7 @@ const recentPosts = posts
         <li>
           <a href={`/blog/${post.slug}/`} aria-label={`Read ${post.data.title}`}>
             <span class="suggestion-title">{post.data.title}</span>
-            <span class="suggestion-meta">{formatDate(post.data.pubDate.toISOString())}</span>
+            <span class="suggestion-meta">{formatDate(toDate(post.data.pubDate).toISOString())}</span>
             <span class="suggestion-summary">{post.data.description ?? ""}</span>
           </a>
         </li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,10 +2,80 @@
 import SiteLayout from "../layouts/SiteLayout.astro";
 import { buttonVariants } from "../components/ui/button";
 import { cn } from "../lib/utils";
-import { getEntry } from "astro:content";
 import GithubActivityCard from "../components/GithubActivityCard.astro";
+import dashboardRaw from "../content/homepage/dashboard.yaml?raw";
 
-const homepageEntry = await getEntry("homepage", "dashboard");
+const parseValue = (input: string) => input.trim().replace(/^"|"$/g, "");
+
+const parseDashboardYaml = (source: string) => {
+  const result: Record<string, any> = {};
+  let currentArray: any[] | null = null;
+  let currentObject: Record<string, any> | null = null;
+
+  const lines = source.split(/\r?\n/);
+
+  for (let i = 0; i < lines.length; i++) {
+    const rawLine = lines[i];
+    if (!rawLine.trim()) continue;
+
+    const indent = rawLine.match(/^ */)?.[0].length ?? 0;
+    const line = rawLine.trim();
+
+    if (indent === 0) {
+      const [keyPart, ...rest] = line.split(":");
+      const key = keyPart.trim();
+      const valuePart = rest.join(":").trim();
+
+      currentArray = null;
+      currentObject = null;
+
+      if (valuePart) {
+        result[key] = parseValue(valuePart);
+        continue;
+      }
+
+      const nextLine = lines.slice(i + 1).find((candidate) => candidate.trim().length > 0);
+      if (nextLine && nextLine.trim().startsWith("- ")) {
+        currentArray = [];
+        result[key] = currentArray;
+      } else {
+        currentObject = {};
+        result[key] = currentObject;
+      }
+      continue;
+    }
+
+    if (indent === 2 && line.startsWith("- ")) {
+      if (!currentArray) continue;
+      const content = line.slice(2).trim();
+      const item: Record<string, any> = {};
+      if (content) {
+        const [itemKey, ...rest] = content.split(":");
+        if (itemKey) {
+          item[itemKey.trim()] = parseValue(rest.join(":").trim());
+        }
+      }
+      currentArray.push(item);
+      currentObject = item;
+      continue;
+    }
+
+    if (indent === 2 && currentObject && !currentArray) {
+      const [propKey, ...rest] = line.split(":");
+      currentObject[propKey.trim()] = parseValue(rest.join(":").trim());
+      continue;
+    }
+
+    if (indent >= 4 && currentObject) {
+      const [propKey, ...rest] = line.split(":");
+      currentObject[propKey.trim()] = parseValue(rest.join(":").trim());
+    }
+  }
+
+  return result;
+};
+
+const homepageEntry = { data: parseDashboardYaml(dashboardRaw) };
 const heroCards = homepageEntry.data.highlightCards;
 const activityCard = homepageEntry.data.activityCard;
 const featureCards = heroCards;

--- a/src/pages/search-index.json.ts
+++ b/src/pages/search-index.json.ts
@@ -2,6 +2,8 @@ import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 import { resolveProjectSlug } from "../lib/projects";
 
+const toDate = (value: unknown) => (value instanceof Date ? value : new Date(String(value)));
+
 export const prerender = true;
 
 const stripMarkdown = (value: string) =>
@@ -43,7 +45,7 @@ export const GET: APIRoute = async () => {
       tags: entry.data.tags ?? [],
       summary: entry.data.description ?? "",
       content: stripMarkdown(entry.body),
-      date: entry.data.pubDate.toISOString(),
+      date: toDate(entry.data.pubDate).toISOString(),
     };
   });
 


### PR DESCRIPTION
## Summary
- replace the Astro content schema with the requested projects/pages definition and add a prebuild slug patcher so Astro retains frontmatter slugs
- refresh the Proxmox homelab entry and normalize project frontmatter/status values while expanding the validation script to parse YAML reliably
- update homepage/search rendering to parse YAML dashboard data and coerce blog dates so 404 suggestions and search indexing still work under the new schema

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fef6ef510483258ee7ce28cf64a068